### PR TITLE
perf(views): adiciona select_related e docstring na HybridSearchView

### DIFF
--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -15,6 +15,12 @@ from .serializers import (
 
 
 class HybridSearchView(APIView):
+    """
+    View responsible for performing a unified search across both product offers and
+    supermarkets. It uses trigram similarity and text filtering to find relevant
+    results based on names, brands, or categories.
+    """
+
     def get(self, request):
         query = request.GET.get("query", "").strip()
         SIMILARITY_THRESHOLD = 0.25
@@ -35,7 +41,10 @@ class HybridSearchView(APIView):
                 | Q(similarity_brand__gt=SIMILARITY_THRESHOLD)
             )
             .select_related(
-                "product", "branch_supermarket__parent_supermarket", "branch_supermarket__location"
+                "product",
+                "product__category",
+                "branch_supermarket__parent_supermarket",
+                "branch_supermarket__location"
             )
             .order_by("-similarity_name")
         )


### PR DESCRIPTION
## O que foi entregue?
Eu adicionei uma docstring para a view `HybridSearchView`, assim como otimizei suas queries usando o `search_related` com o argumento `product__category`.

Closes #31.

## ✅ Critérios de Aceite (Checklist)
- [X] A funcionalidade foi testada no simulador/celular.
- [ ] O código está coberto por testes e foi adotado o TDD.
- [X] O código segue as regras de estilização definidas no projeto.
- [X] Todo o código está em Inglês.