### PR TITLE
Refatoração do layout do card de produto e correção de design dos cards

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,11 +17,11 @@ class Product(models.Model):
     """Class representing the 'Product' entity in the database."""
 
     class MeasurementUnit(models.TextChoices):
-        KG = "KG", "Quilo"
-        G = "G", "Grama"
-        L = "L", "Litro"
-        ML = "ML", "Mililitro"
-        UN = "UN", "Unidade"
+        KG = "KG", "KG"
+        G = "G", "G"
+        L = "L", "L"
+        ML = "ML", "ML"
+        UN = "UN", "UN"
 
     name = models.CharField(max_length=50, blank=False)
     category = models.ForeignKey(Category, on_delete=models.CASCADE, related_name="products")

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -51,7 +51,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    "silk.middleware.SilkyMiddleware",
+    #"silk.middleware.SilkyMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/frontend/src/components/EmptyProductState.tsx
+++ b/frontend/src/components/EmptyProductState.tsx
@@ -1,33 +1,36 @@
+import { Feather } from "@expo/vector-icons";
 import { StyleSheet, Text, View } from "react-native";
-import { Feather } from "@expo/vector-icons"; 
 
 interface EmptyProductStateProps {
   isSearchEmpty?: boolean;
 }
 
-export const EmptyProductState = ({ isSearchEmpty = false }: EmptyProductStateProps) => (
+export const EmptyProductState = ({
+  isSearchEmpty = false,
+}: EmptyProductStateProps) => (
   <View style={styles.container}>
     <View style={styles.iconRow}>
       <View style={styles.stickmanWrapper}>
-
-        <Feather 
-          name={isSearchEmpty ? "search" : "check"} 
-          size={18} 
-          color="#A0AAB2" 
-          style={styles.topIcon} 
+        <Feather
+          name={isSearchEmpty ? "search" : "check"}
+          size={18}
+          color="#A0AAB2"
+          style={styles.topIcon}
         />
         <Feather name="user" size={32} color="#A0AAB2" />
       </View>
     </View>
 
     <Text style={styles.title}>
-      {isSearchEmpty ? "Nenhum produto encontrado" : "Você chegou ao fim das ofertas."}
+      {isSearchEmpty
+        ? "Nenhum produto encontrado"
+        : "Você chegou ao fim das ofertas."}
     </Text>
     <Text style={styles.subtitle}>
-      {isSearchEmpty 
-        ? "Ops! Não conseguimos localizar as ofertas. Verifique se o seu Wi-Fi está ativo ou tente atualizar a página em alguns instantes." 
+      {isSearchEmpty
+        ? "Ops! Não conseguimos localizar as ofertas. Verifique se o seu Wi-Fi está ativo ou tente atualizar a página em alguns instantes."
         : "Ufa! Você percorreu todas as nossas ofertas atuais."}
-    </Text> 
+    </Text>
   </View>
 );
 
@@ -39,28 +42,28 @@ const styles = StyleSheet.create({
     marginTop: 20,
   },
   iconRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-end', 
+    flexDirection: "row",
+    alignItems: "flex-end",
     marginBottom: 15,
   },
 
   icon: {
     fontSize: 30,
-    marginRight: 10, 
+    marginRight: 10,
   },
   stickmanWrapper: {
-    alignItems: 'center',
+    alignItems: "center",
   },
 
   topIcon: {
-    marginBottom: -4, 
+    marginBottom: -4,
   },
   questionMark: {
     fontSize: 16,
     color: "#A0AAB2",
     fontWeight: "bold",
-    marginBottom: -6, 
-    marginLeft: 15,   
+    marginBottom: -6,
+    marginLeft: 15,
   },
   title: {
     fontSize: 18,

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -1,14 +1,14 @@
-import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { FontAwesome5, MaterialCommunityIcons } from "@expo/vector-icons";
 import React, { memo } from "react";
-import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Dimensions, Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import type { Product } from "../types/product";
+
 
 interface ProductCardProps {
   product: Product;
   ranking?: number;
   handlePress: (product: Product) => void;
   handleAddToList: (product: Product) => void;
-  isGrid?: boolean;
 }
 
 const ProductCard: React.FC<ProductCardProps> = ({
@@ -18,6 +18,10 @@ const ProductCard: React.FC<ProductCardProps> = ({
   handleAddToList,
   isGrid,
 }) => {
+
+  const screenWidth = Dimensions.get("window").width;
+  const isSmallDevice = screenWidth < 360;
+
   const formattedDistance = React.useMemo(() => {
     if (product.distanceInKilometers === undefined) return null;
     if (product.distanceInKilometers === null) return null;
@@ -31,7 +35,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
 
   return (
     <TouchableOpacity
-      style={[styles.card, isGrid ? styles.gridStyle : styles.listStyle]}
+      style={[styles.card, { padding: isSmallDevice ? 8 : 12 }]}
       onPress={() => handlePress(product)}
       activeOpacity={0.9}
     >
@@ -43,24 +47,11 @@ const ProductCard: React.FC<ProductCardProps> = ({
         />
 
         <View style={styles.rankingBadge}>
-          <Text style={styles.rankingText}>
-            #{ranking || product.id}
-          </Text>
+          <Text style={styles.rankingText}>#{ranking || product.id}</Text>
         </View>
 
-        <View
-          style={[
-            styles.priceLabel,
-            isGrid && {
-              minWidth: undefined,
-              height: 23,
-              paddingHorizontal: 6,
-              top: 10,
-              right: 6,
-            },
-          ]}
-        >
-          <Text style={[styles.priceText, isGrid && { fontSize: 11 }]}>
+        <View style={styles.priceLabel}>
+          <Text style={[styles.priceText, { fontSize: isSmallDevice ? 10 : 11 }]}>
             R$ {Number(product.price).toFixed(2).replace(".", ",")}
           </Text>
         </View>
@@ -68,65 +59,59 @@ const ProductCard: React.FC<ProductCardProps> = ({
         <TouchableOpacity
           style={[
             styles.addButton,
-            isGrid && { width: 30, height: 30, borderRadius: 15, bottom: 8 },
+            { 
+              width: isSmallDevice ? 26 : 30, 
+              height: isSmallDevice ? 26 : 30, 
+              borderRadius: isSmallDevice ? 13 : 15 
+            }
           ]}
           onPress={() => handleAddToList(product)}
         >
           <MaterialCommunityIcons
             name="playlist-plus"
-            size={isGrid ? 20 : 24}
+            size={isSmallDevice ? 16 : 18}
             color="#28a8b5"
           />
         </TouchableOpacity>
       </View>
 
       <View style={styles.infoContainer}>
-        <View style={isGrid ? { height: 44, justifyContent: "center" } : null}>
-          <Text
-            style={[
-              styles.productName,
-              isGrid && { fontSize: 13, lineHeight: 16 },
-            ]}
-            numberOfLines={2}
-          >
-            {product.productName}
-          </Text>
+        <View style={styles.topInfoRow}>
+          <View style={styles.productNameWrapper}>
+            <Text style={styles.productName} numberOfLines={2}>
+              {product.productName}
+              {product.measurement 
+                ? ` | ${Math.floor(Number(product.measurement))} ${product.measurementUnit || ""}` 
+                : product.measurementUnit 
+                ? ` | ${product.measurementUnit}` 
+                : ""
+              }
+            </Text>
+          </View>
+          
+          <View style={styles.marketWrapper}>
+            <Text style={styles.marketName} numberOfLines={1}>
+              {product.marketName}
+            </Text>
+          </View>
         </View>
 
-        <View
-          style={
-            isGrid
-              ? { height: 20, justifyContent: "center", marginTop: 2 }
-              : null
-          }
-        >
+        <View style={styles.bottomInfoRow}>
           <Text style={styles.brandStyle} numberOfLines={1}>
             {product.brand}
           </Text>
-        </View>
 
-        <View style={[styles.footerLine, isGrid && { marginTop: 5 }]}>
-          {product.measurementUnit && (
-            <View style={styles.weightLabel}>
-              <Text style={styles.weightText}>{product.measurementUnit}</Text>
+          {formattedDistance && (
+            <View style={styles.distanceWrapper}>
+              <View style={styles.iconContainer}>
+                <FontAwesome5 name="walking" size={8} color="#999" />
+                <View style={styles.dashLine} />
+                <FontAwesome5 name="map-marker-alt" size={8} color="#999" />
+              </View>
+              <Text style={styles.distanceText}>{formattedDistance}</Text>
             </View>
           )}
-
-          <Text style={styles.marketName} numberOfLines={1}>
-            {product.marketName}
-          </Text>
         </View>
-
-        {formattedDistance && (
-          <View style={styles.distanceContainer}>
-            <MaterialCommunityIcons
-              name="map-marker-distance"
-              size={12}
-              color="#666"
-            />
-            <Text style={styles.distanceText}>{formattedDistance}</Text>
-          </View>
-        )}
       </View>
     </TouchableOpacity>
   );
@@ -157,7 +142,7 @@ const styles = StyleSheet.create({
     position: "relative",
     overflow: "hidden",
     borderRadius: 12,
-    marginBottom: 5,
+    marginBottom: 8,
     backgroundColor: "#f9f9f9",
     justifyContent: "center",
     alignItems: "center",
@@ -168,8 +153,18 @@ const styles = StyleSheet.create({
   },
   productName: {
     fontWeight: "700",
-    fontSize: 14,
+    fontSize: 11,
     color: "#333",
+  },
+  marketName: {
+    fontSize: 10,
+    fontWeight: "600",
+    color: "#28a8b5",
+    textAlign: "right",
+  },
+  marketWrapper: {
+    flex: 0.7, 
+    alignItems: "flex-end",
   },
   rankingBadge: {
     position: "absolute",
@@ -181,7 +176,6 @@ const styles = StyleSheet.create({
     borderRadius: 6,
     borderWidth: 1,
     borderColor: "#eee",
-    elevation: 2,
   },
   rankingText: {
     fontSize: 10,
@@ -189,15 +183,14 @@ const styles = StyleSheet.create({
     fontWeight: "bold",
   },
   priceLabel: {
-    minWidth: 65,
-    paddingVertical: 4,
+    minWidth: 30,
+    paddingHorizontal: 6,
+    paddingVertical: 3,
     backgroundColor: "#28a8b5",
     borderRadius: 6,
     position: "absolute",
     top: 8,
     right: 8,
-    justifyContent: "center",
-    alignItems: "center",
   },
   priceText: {
     color: "#ffffff",
@@ -206,24 +199,40 @@ const styles = StyleSheet.create({
   },
   addButton: {
     position: "absolute",
-    bottom: 16,
+    bottom: 10,
     alignSelf: "center",
-    width: 42,
-    height: 42,
-    borderRadius: 21,
+    borderRadius: 5,
     backgroundColor: "#FFFFFF",
     justifyContent: "center",
     alignItems: "center",
     elevation: 4,
   },
   infoContainer: {
-    paddingVertical: 4,
-    flex: 1,
+    paddingVertical: 2,
+    gap: 2,
+  },
+  topInfoRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+  },
+  bottomInfoRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    marginTop: 2,
+  },
+  productNameWrapper: {
+    flex: 1.3,
+    paddingRight: 10,
   },
   brandStyle: {
-    fontSize: 11,
+    fontSize: 10,
     color: "#888",
     textTransform: "uppercase",
+  },
+  brandWrapper: {
+    flex: 1,
   },
   footerLine: {
     flexDirection: "row",
@@ -242,22 +251,27 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: "#666",
   },
-  marketName: {
-    fontSize: 11,
-    fontWeight: "700",
-    color: "#28a8b5",
-    flex: 1,
+  distanceWrapper: {
+    alignItems: "flex-end",
+    justifyContent: "center",
+    flexDirection: "column",
   },
-  distanceContainer: {
-    flexDirection: "row",
+  iconContainer: {
+    flexDirection: "row",    
     alignItems: "center",
-    marginTop: 4,
+    marginBottom: 2,         
+  },
+  dashLine: {
+    width: 8,
+    height: 1,
+    backgroundColor: "#999", 
+    marginHorizontal: 3,
   },
   distanceText: {
-    fontSize: 11,
+    fontSize: 10,
     color: "#999",
-    marginLeft: 3,
     fontWeight: "600",
+    textAlign: "right",
   },
 });
 

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -1,8 +1,14 @@
 import { FontAwesome5, MaterialCommunityIcons } from "@expo/vector-icons";
 import React, { memo } from "react";
-import { Dimensions, Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import {
+  Dimensions,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import type { Product } from "../types/product";
-
 
 interface ProductCardProps {
   product: Product;
@@ -17,7 +23,6 @@ const ProductCard: React.FC<ProductCardProps> = ({
   handlePress,
   handleAddToList,
 }) => {
-
   const screenWidth = Dimensions.get("window").width;
   const isSmallDevice = screenWidth < 360;
 
@@ -50,7 +55,9 @@ const ProductCard: React.FC<ProductCardProps> = ({
         </View>
 
         <View style={styles.priceLabel}>
-          <Text style={[styles.priceText, { fontSize: isSmallDevice ? 10 : 11 }]}>
+          <Text
+            style={[styles.priceText, { fontSize: isSmallDevice ? 10 : 11 }]}
+          >
             R$ {Number(product.price).toFixed(2).replace(".", ",")}
           </Text>
         </View>
@@ -58,11 +65,11 @@ const ProductCard: React.FC<ProductCardProps> = ({
         <TouchableOpacity
           style={[
             styles.addButton,
-            { 
-              width: isSmallDevice ? 26 : 30, 
-              height: isSmallDevice ? 26 : 30, 
-              borderRadius: isSmallDevice ? 13 : 15 
-            }
+            {
+              width: isSmallDevice ? 26 : 30,
+              height: isSmallDevice ? 26 : 30,
+              borderRadius: isSmallDevice ? 13 : 15,
+            },
           ]}
           onPress={() => handleAddToList(product)}
         >
@@ -79,15 +86,14 @@ const ProductCard: React.FC<ProductCardProps> = ({
           <View style={styles.productNameWrapper}>
             <Text style={styles.productName} numberOfLines={2}>
               {product.productName}
-              {product.measurement 
-                ? ` | ${Math.floor(Number(product.measurement))} ${product.measurementUnit || ""}` 
-                : product.measurementUnit 
-                ? ` | ${product.measurementUnit}` 
-                : ""
-              }
+              {product.measurement
+                ? ` | ${Math.floor(Number(product.measurement))} ${product.measurementUnit || ""}`
+                : product.measurementUnit
+                  ? ` | ${product.measurementUnit}`
+                  : ""}
             </Text>
           </View>
-          
+
           <View style={styles.marketWrapper}>
             <Text style={styles.marketName} numberOfLines={1}>
               {product.marketName}
@@ -162,7 +168,7 @@ const styles = StyleSheet.create({
     textAlign: "right",
   },
   marketWrapper: {
-    flex: 0.7, 
+    flex: 0.7,
     alignItems: "flex-end",
   },
   rankingBadge: {
@@ -256,14 +262,14 @@ const styles = StyleSheet.create({
     flexDirection: "column",
   },
   iconContainer: {
-    flexDirection: "row",    
+    flexDirection: "row",
     alignItems: "center",
-    marginBottom: 2,         
+    marginBottom: 2,
   },
   dashLine: {
     width: 8,
     height: 1,
-    backgroundColor: "#999", 
+    backgroundColor: "#999",
     marginHorizontal: 3,
   },
   distanceText: {

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -16,7 +16,6 @@ const ProductCard: React.FC<ProductCardProps> = ({
   ranking,
   handlePress,
   handleAddToList,
-  isGrid,
 }) => {
 
   const screenWidth = Dimensions.get("window").width;

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -49,7 +49,13 @@ export const ProductGrid: React.FC<ProductGridProps> = ({
       data={products}
       keyExtractor={(item, index) => `${item.id}-${index}`}
       renderItem={({ item, index }) => (
-        <View style={[styles.cardWrapper, { maxWidth: `${100 / numColumns}%` }]}>
+        <View 
+          style={
+            numColumns > 1 
+              ? [styles.cardWrapper, { maxWidth: `${100 / numColumns}%` }]
+              : { width: "100%", padding: 6 } // Layout limpo e em largura cheia para celulares ultra finos
+          }
+        >
           <ProductCard
             product={item}
             ranking={index + 1}

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type React from "react";
 import { FlatList, StyleSheet, useWindowDimensions, View } from "react-native";
 import type { Product } from "../types/product";
 import ProductCard from "./ProductCard";
@@ -9,17 +9,15 @@ interface ProductGridProps {
   handleAddToList: (product: Product) => void;
   onEndReached?: () => void;
   onEndReachedThreshold?: number;
-  ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
-  ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
-  ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
+  listFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
+  listHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
+  listEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
   contentContainerStyle?: any;
 }
 
-const BREAKPOINTS = {
-  TABLET_LARGE: 1024,
-  TABLET_STANDARD: 768,
-  MOBILE_STANDARD: 320,
-};
+const TABLET_LARGE = 1024;
+const TABLET_STANDARD = 768;
+const MOBILE_STANDARD = 320;
 
 export const ProductGrid: React.FC<ProductGridProps> = ({
   products,
@@ -27,18 +25,18 @@ export const ProductGrid: React.FC<ProductGridProps> = ({
   handleAddToList,
   onEndReached,
   onEndReachedThreshold,
-  ListFooterComponent,
-  ListHeaderComponent,
-  ListEmptyComponent,
+  listFooterComponent,
+  listHeaderComponent,
+  listEmptyComponent,
   contentContainerStyle,
 }) => {
   const { width } = useWindowDimensions();
 
   // This function calculates the number of columns for the grid based on the current screen width and predefined breakpoints. It ensures that the grid is responsive and adapts to different device sizes, providing an optimal layout for users on mobile, tablet, and larger screens.
   const getNumColumns = (): number => {
-    if (width >= BREAKPOINTS.TABLET_LARGE) return 4;
-    if (width >= BREAKPOINTS.TABLET_STANDARD) return 3;
-    if (width >= BREAKPOINTS.MOBILE_STANDARD) return 2;
+    if (width >= TABLET_LARGE) return 4;
+    if (width >= TABLET_STANDARD) return 3;
+    if (width >= MOBILE_STANDARD) return 2;
     return 1;
   };
 
@@ -49,11 +47,11 @@ export const ProductGrid: React.FC<ProductGridProps> = ({
       data={products}
       keyExtractor={(item, index) => `${item.id}-${index}`}
       renderItem={({ item, index }) => (
-        <View 
+        <View
           style={
-            numColumns > 1 
+            numColumns > 1
               ? [styles.cardWrapper, { maxWidth: `${100 / numColumns}%` }]
-              : { width: "100%", padding: 6 } // Layout limpo e em largura cheia para celulares ultra finos
+              : { width: "100%", padding: 6 }
           }
         >
           <ProductCard
@@ -66,16 +64,15 @@ export const ProductGrid: React.FC<ProductGridProps> = ({
       )}
       key={`grid-${numColumns}`}
       numColumns={numColumns}
-      
       //
       columnWrapperStyle={numColumns > 1 ? styles.rowWrapper : null}
-      contentContainerStyle={[styles.listContainer, contentContainerStyle]}      
-      // 
+      contentContainerStyle={[styles.listContainer, contentContainerStyle]}
+      //
       onEndReached={onEndReached}
       onEndReachedThreshold={onEndReachedThreshold}
-      ListFooterComponent={ListFooterComponent}
-      ListHeaderComponent={ListHeaderComponent}
-      ListEmptyComponent={ListEmptyComponent}
+      ListFooterComponent={listFooterComponent}
+      ListHeaderComponent={listHeaderComponent}
+      ListEmptyComponent={listEmptyComponent}
     />
   );
 };
@@ -85,7 +82,7 @@ const styles = StyleSheet.create({
     padding: 6,
   },
   rowWrapper: {
-    justifyContent: "flex-start", 
+    justifyContent: "flex-start",
     flexDirection: "row",
     width: "100%",
   },
@@ -93,6 +90,6 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     flexShrink: 0,
     flexBasis: 0,
-    padding: 6, 
+    padding: 6,
   },
 });

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { FlatList, StyleSheet, useWindowDimensions, View } from "react-native";
+import type { Product } from "../types/product";
+import ProductCard from "./ProductCard";
+
+interface ProductGridProps {
+  products: Product[];
+  handlePress: (product: Product) => void;
+  handleAddToList: (product: Product) => void;
+  onEndReached?: () => void;
+  onEndReachedThreshold?: number;
+  ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
+  ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
+  ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
+  contentContainerStyle?: any;
+}
+
+const BREAKPOINTS = {
+  TABLET_LARGE: 1024,
+  TABLET_STANDARD: 768,
+  MOBILE_STANDARD: 320,
+};
+
+export const ProductGrid: React.FC<ProductGridProps> = ({
+  products,
+  handlePress,
+  handleAddToList,
+  onEndReached,
+  onEndReachedThreshold,
+  ListFooterComponent,
+  ListHeaderComponent,
+  ListEmptyComponent,
+  contentContainerStyle,
+}) => {
+  const { width } = useWindowDimensions();
+
+  // This function calculates the number of columns for the grid based on the current screen width and predefined breakpoints. It ensures that the grid is responsive and adapts to different device sizes, providing an optimal layout for users on mobile, tablet, and larger screens.
+  const getNumColumns = (): number => {
+    if (width >= BREAKPOINTS.TABLET_LARGE) return 4;
+    if (width >= BREAKPOINTS.TABLET_STANDARD) return 3;
+    if (width >= BREAKPOINTS.MOBILE_STANDARD) return 2;
+    return 1;
+  };
+
+  const numColumns = getNumColumns();
+
+  return (
+    <FlatList
+      data={products}
+      keyExtractor={(item, index) => `${item.id}-${index}`}
+      renderItem={({ item, index }) => (
+        <View style={[styles.cardWrapper, { maxWidth: `${100 / numColumns}%` }]}>
+          <ProductCard
+            product={item}
+            ranking={index + 1}
+            handlePress={handlePress}
+            handleAddToList={handleAddToList}
+          />
+        </View>
+      )}
+      key={`grid-${numColumns}`}
+      numColumns={numColumns}
+      
+      //
+      columnWrapperStyle={numColumns > 1 ? styles.rowWrapper : null}
+      contentContainerStyle={[styles.listContainer, contentContainerStyle]}      
+      // 
+      onEndReached={onEndReached}
+      onEndReachedThreshold={onEndReachedThreshold}
+      ListFooterComponent={ListFooterComponent}
+      ListHeaderComponent={ListHeaderComponent}
+      ListEmptyComponent={ListEmptyComponent}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  listContainer: {
+    padding: 6,
+  },
+  rowWrapper: {
+    justifyContent: "flex-start", 
+    flexDirection: "row",
+    width: "100%",
+  },
+  cardWrapper: {
+    flexGrow: 1,
+    flexShrink: 0,
+    flexBasis: 0,
+    padding: 6, 
+  },
+});

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   Dimensions,
+  Platform,
   StyleSheet,
   Text,
   TextInput,
@@ -11,7 +12,6 @@ import {
 } from "react-native";
 import { fetchHybridSearch } from "../api/search";
 import { colors } from "../theme/colors";
-import { Platform } from 'react-native';
 
 const { width: screenWidth } = Dimensions.get("window");
 
@@ -68,7 +68,7 @@ export const SearchBar = ({ initialValue = "" }: SearchBarProps) => {
       <View style={styles.searchContainer}>
         <TextInput
           style={[
-            // @ts-ignore
+            // @ts-expect-error
             styles.input,
             { fontSize: isUltraNarrow ? 13 : isSmall ? 14 : 16 },
           ]}
@@ -174,10 +174,10 @@ const styles = StyleSheet.create({
     paddingRight: isUltraNarrow ? 20 : 35,
     color: colors.textPrimary,
     ...Platform.select({
-      'web': {
+      web: {
         outlineStyle: "none",
-      }
-    })
+      },
+    }),
   },
   iconContainer: {
     width: isUltraNarrow ? 55 : isSmall ? "20%" : 85,

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,19 +1,18 @@
 import { useNavigation } from "@react-navigation/native";
 import type * as Location from "expo-location";
 import React, { useCallback, useEffect, useState } from "react";
-import { FlatList, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { fetchMarkets } from "../api/markets";
 import { fetchProducts } from "../api/products";
 import { EmptyProductState } from "../components/EmptyProductState";
+import { ProductGrid } from "../components/ProductGrid";
 import { HomeHeader } from "../components/HomeScreenHeader";
 import { LoadingFooter } from "../components/LoadingFooter";
-import ProductCard from "../components/ProductCard";
 import type { Market } from "../types/market";
 import type { Product } from "../types/product";
 
 // SUPPORT FUNCTIONS
-const renderSeparator = () => <View style={styles.separator} />;
 
 export function HomeScreen({location}: {location: Location.LocationObject}) {
   const insets = useSafeAreaInsets();
@@ -102,17 +101,6 @@ export function HomeScreen({location}: {location: Location.LocationObject}) {
     loadMarkets();
   }, [location]);
 
-  const renderItem = useCallback(
-  ({ item, index }: { item: Product; index: number }) => (
-    <ProductCard
-      product={item}
-      ranking={index + 1}
-      handlePress={handlePress}
-      handleAddToList={handleAdd}
-    />
-  ),
-  [handlePress, handleAdd]
-);
 
  const renderFooter = () => {
 
@@ -131,43 +119,33 @@ export function HomeScreen({location}: {location: Location.LocationObject}) {
   return null;
 };
 
-const dynamicPadding = hasMoreData ? insets.bottom + 20: insets.bottom + 10;
-
   return (
     <View style={{ flex: 1, backgroundColor: "#FFF", paddingTop: insets.top }}>
-      <FlatList
-        data={products}
-        initialNumToRender={10}
-        windowSize={5}
-        renderItem={renderItem}
-        keyExtractor={(item, index) => `${item.id}-${index}`}
-        style={{ flex: 1 }}
-        contentContainerStyle={[
-          styles.listContent,
-          { paddingBottom: insets.bottom + 5 },
-        ]}
-        ItemSeparatorComponent={renderSeparator}
+      <ProductGrid
+        products={products}
+        handlePress={handlePress}
+        handleAddToList={handleAdd}
+        onEndReached={fetchProductsData}
+        onEndReachedThreshold={0.7}
+        ListFooterComponent={renderFooter()}
         ListHeaderComponent={
           <HomeHeader
             markets={markets}
             handleMarketPress={handleMarketPress}
           />
         }
-        showsVerticalScrollIndicator={false}
-        onEndReached={fetchProductsData}
-        onEndReachedThreshold={0.7}
-        ListFooterComponent={renderFooter}
+        contentContainerStyle={[
+          styles.gridContainer,
+          { paddingBottom: insets.bottom + 5 },
+        ]}
       />
     </View>
   );
 }
 
 export const styles = StyleSheet.create({
-  listContent: {
-    paddingHorizontal: 15,
+  gridContainer: {
+    paddingHorizontal: 14,
     flexGrow: 1,
-  },
-  separator: {
-    height: 12,
   },
 });

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,20 +1,24 @@
 import { useNavigation } from "@react-navigation/native";
 import type * as Location from "expo-location";
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { fetchMarkets } from "../api/markets";
 import { fetchProducts } from "../api/products";
 import { EmptyProductState } from "../components/EmptyProductState";
-import { ProductGrid } from "../components/ProductGrid";
 import { HomeHeader } from "../components/HomeScreenHeader";
 import { LoadingFooter } from "../components/LoadingFooter";
+import { ProductGrid } from "../components/ProductGrid";
 import type { Market } from "../types/market";
 import type { Product } from "../types/product";
 
 // SUPPORT FUNCTIONS
 
-export function HomeScreen({location}: {location: Location.LocationObject}) {
+export function HomeScreen({
+  location,
+}: {
+  location: Location.LocationObject;
+}) {
   const insets = useSafeAreaInsets();
   const [products, setProducts] = useState<Product[]>([]);
   const [page, setPage] = useState(1);
@@ -101,23 +105,21 @@ export function HomeScreen({location}: {location: Location.LocationObject}) {
     loadMarkets();
   }, [location]);
 
+  const renderFooter = () => {
+    if (isLoading && products.length > 0) {
+      return <LoadingFooter isLoading={isLoading} />;
+    }
 
- const renderFooter = () => {
+    if (!isLoading && products.length === 0 && !hasMoreData) {
+      return <EmptyProductState isSearchEmpty={true} />;
+    }
 
-  if (isLoading && products.length > 0) {
-    return <LoadingFooter isLoading={isLoading} />;
-  }
+    if (!isLoading && !hasMoreData && products.length > 0) {
+      return <EmptyProductState isSearchEmpty={false} />;
+    }
 
-  if (!isLoading && products.length === 0 && !hasMoreData) {
-    return <EmptyProductState isSearchEmpty={true} />;
-  }
-
-  if (!isLoading && !hasMoreData && products.length > 0) {
-    return <EmptyProductState isSearchEmpty={false} />;
-  }
-
-  return null;
-};
+    return null;
+  };
 
   return (
     <View style={{ flex: 1, backgroundColor: "#FFF", paddingTop: insets.top }}>
@@ -127,12 +129,9 @@ export function HomeScreen({location}: {location: Location.LocationObject}) {
         handleAddToList={handleAdd}
         onEndReached={fetchProductsData}
         onEndReachedThreshold={0.7}
-        ListFooterComponent={renderFooter()}
-        ListHeaderComponent={
-          <HomeHeader
-            markets={markets}
-            handleMarketPress={handleMarketPress}
-          />
+        listFooterComponent={renderFooter()}
+        listHeaderComponent={
+          <HomeHeader markets={markets} handleMarketPress={handleMarketPress} />
         }
         contentContainerStyle={[
           styles.gridContainer,

--- a/frontend/src/screens/StoreProductsScreen.tsx
+++ b/frontend/src/screens/StoreProductsScreen.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
-import { FlatList, StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
+import { ProductGrid } from "../components/ProductGrid";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { fetchProducts } from "../api/products";
 import { LoadingFooter } from "../components/LoadingFooter";
-import ProductCard from "../components/ProductCard";
 import { SearchBar } from "../components/SearchBar";
 import type { Product } from "../types/product";
+import { EmptyProductState } from "../components/EmptyProductState";
 
 export function StoreProductsScreen({ route }: any) {
   const insets = useSafeAreaInsets();
@@ -69,6 +70,19 @@ export function StoreProductsScreen({ route }: any) {
     );
   };
 
+  const renderFooter = () => {
+    if (isLoading && products.length > 0) {
+      return <LoadingFooter isLoading={isLoading} />;
+    }
+    if (!isLoading && products.length === 0 && !hasMoreData) {
+      return <EmptyProductState />;
+    }
+    if (!isLoading && !hasMoreData && products.length > 0) {
+      return <EmptyProductState />;
+    }
+    return null;
+  };
+
   return (
     <View
       style={{
@@ -81,33 +95,22 @@ export function StoreProductsScreen({ route }: any) {
         style={{
           zIndex: 10,
           backgroundColor: "#FFF",
-          paddingHorizontal: 20,
-          paddingBottom: 15,
+          paddingHorizontal: 14,
+          paddingBottom: 10, // 🎯 ADICIONADO: Evita que a SearchBar grude fisicamente no banner do mercado abaixo
         }}
       >
         <SearchBar />
       </View>
 
-      <FlatList
-        data={products}
-        keyExtractor={(item) => item.id.toString()}
-        renderItem={({ item, index }) => (
-          <View style={styles.cardWrapper}>
-            <ProductCard
-              product={{ ...item, ranking: index + 1 }}
-              isGrid={true}
-              handlePress={() => console.log("Details")}
-              handleAddToList={() => console.log("Add to List")}
-            />
-          </View>
-        )}
-        numColumns={2}
-        columnWrapperStyle={styles.gridRow}
-        ListHeaderComponent={Header}
-        ListFooterComponent={() => <LoadingFooter isLoading={isLoading} />}
+      <ProductGrid
+        products={products}
+        handlePress={(product) => console.log("Details for:", product.productName)}
+        handleAddToList={(product) => console.log("Add to List:", product.productName)}
         onEndReached={fetchData}
-        onEndReachedThreshold={0.5}
-        contentContainerStyle={styles.gridContainer}
+        onEndReachedThreshold={0.7}
+        ListHeaderComponent={<Header />}
+        ListFooterComponent={renderFooter()}
+        contentContainerStyle={styles.gridContainer} 
       />
     </View>
   );
@@ -115,31 +118,24 @@ export function StoreProductsScreen({ route }: any) {
 
 const styles = StyleSheet.create({
   headerContainer: {
+    width: "100%",
     paddingBottom: 10,
   },
   gridContainer: {
-    paddingHorizontal: 20,
-    paddingBottom: 20,
-  },
-  gridRow: {
-    justifyContent: "flex-start",
-  },
-  cardWrapper: {
-    flex: 1,
-    maxWidth: "50%",
-    marginHorizontal: 5,
-    marginBottom: 10,
+    paddingHorizontal: 14, 
+    flexGrow: 1, // 🎯 DESCOMENTADO: Essencial para que a lista preencha a tela corretamente e alinhe o rodapé
   },
   marketBanner: {
     flexDirection: "row",
     alignItems: "center",
     padding: 15,
     backgroundColor: "#FFF",
-    marginHorizontal: 10,
+    marginHorizontal: 0, // 🎯 CORREÇÃO CRUCIAL: Mudado de 6 para 0! Agora ele segue a linha guia de 14px perfeitamente, sem entortar a grade de baixo
     borderRadius: 12,
     marginBottom: 10,
     borderWidth: 1,
     borderColor: "#EEE",
+    alignSelf: "stretch",
   },
   marketInitials: {
     fontSize: 20,

--- a/frontend/src/screens/StoreProductsScreen.tsx
+++ b/frontend/src/screens/StoreProductsScreen.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
-import { ProductGrid } from "../components/ProductGrid";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { fetchProducts } from "../api/products";
+import { EmptyProductState } from "../components/EmptyProductState";
 import { LoadingFooter } from "../components/LoadingFooter";
+import { ProductGrid } from "../components/ProductGrid";
 import { SearchBar } from "../components/SearchBar";
 import type { Product } from "../types/product";
-import { EmptyProductState } from "../components/EmptyProductState";
 
 export function StoreProductsScreen({ route }: any) {
   const insets = useSafeAreaInsets();
@@ -96,7 +96,7 @@ export function StoreProductsScreen({ route }: any) {
           zIndex: 10,
           backgroundColor: "#FFF",
           paddingHorizontal: 14,
-          paddingBottom: 10, 
+          paddingBottom: 10,
         }}
       >
         <SearchBar />
@@ -104,13 +104,17 @@ export function StoreProductsScreen({ route }: any) {
 
       <ProductGrid
         products={products}
-        handlePress={(product) => console.log("Details for:", product.productName)}
-        handleAddToList={(product) => console.log("Add to List:", product.productName)}
+        handlePress={(product) =>
+          console.log("Details for:", product.productName)
+        }
+        handleAddToList={(product) =>
+          console.log("Add to List:", product.productName)
+        }
         onEndReached={fetchData}
         onEndReachedThreshold={0.7}
         ListHeaderComponent={<Header />}
         ListFooterComponent={renderFooter()}
-        contentContainerStyle={styles.gridContainer} 
+        contentContainerStyle={styles.gridContainer}
       />
     </View>
   );
@@ -122,15 +126,15 @@ const styles = StyleSheet.create({
     paddingBottom: 10,
   },
   gridContainer: {
-    paddingHorizontal: 14, 
-    flexGrow: 1, 
+    paddingHorizontal: 14,
+    flexGrow: 1,
   },
   marketBanner: {
     flexDirection: "row",
     alignItems: "center",
     padding: 15,
     backgroundColor: "#FFF",
-    marginHorizontal: 0, 
+    marginHorizontal: 0,
     borderRadius: 12,
     marginBottom: 10,
     borderWidth: 1,

--- a/frontend/src/screens/StoreProductsScreen.tsx
+++ b/frontend/src/screens/StoreProductsScreen.tsx
@@ -71,7 +71,7 @@ export function StoreProductsScreen({ route }: any) {
   };
 
   const renderFooter = () => {
-    if (isLoading && products.length > 0) {
+    if (isLoading) {
       return <LoadingFooter isLoading={isLoading} />;
     }
     if (!isLoading && products.length === 0 && !hasMoreData) {
@@ -96,7 +96,7 @@ export function StoreProductsScreen({ route }: any) {
           zIndex: 10,
           backgroundColor: "#FFF",
           paddingHorizontal: 14,
-          paddingBottom: 10, // 🎯 ADICIONADO: Evita que a SearchBar grude fisicamente no banner do mercado abaixo
+          paddingBottom: 10, 
         }}
       >
         <SearchBar />
@@ -123,14 +123,14 @@ const styles = StyleSheet.create({
   },
   gridContainer: {
     paddingHorizontal: 14, 
-    flexGrow: 1, // 🎯 DESCOMENTADO: Essencial para que a lista preencha a tela corretamente e alinhe o rodapé
+    flexGrow: 1, 
   },
   marketBanner: {
     flexDirection: "row",
     alignItems: "center",
     padding: 15,
     backgroundColor: "#FFF",
-    marginHorizontal: 0, // 🎯 CORREÇÃO CRUCIAL: Mudado de 6 para 0! Agora ele segue a linha guia de 14px perfeitamente, sem entortar a grade de baixo
+    marginHorizontal: 0, 
     borderRadius: 12,
     marginBottom: 10,
     borderWidth: 1,

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -15,7 +15,7 @@ export interface Product {
 export interface ProductCardProps {
   product: Product;
   handlePress: (product: Product) => void;
-  ranking?: number; 
+  ranking?: number;
   handleAddToList: (product: Product) => void;
   isGrid?: boolean;
 }


### PR DESCRIPTION
---

# #26 - Reestruturação do Layout do Card de Produto e Alinhamento de Hierarquia

## O que foi entregue?

> Refatorei o componente `ProductCard.tsx` para seguir fielmente o alinhamento de colunas paralelas do wireframe, garantindo responsividade em telas menores. Implementei a lógica de exibição combinada de quantidade e unidade de medida tratada por `Math.floor()` (`Ex: 1 - KG`). 

> No rodapé, alinhei a base vertical da Marca com o texto de distância e adicionei uma linha geométrica com ícones de trajeto (`walking` e `map-marker-alt`). No backend, ajustei o `MeasurementUnit` no `models.py` e atualizei o `BranchProductOfferSerializer` para retornar estritamente as siglas brutas das unidades.

> 💡 Nota de Revisão (Backend):
Sobre a classe MeasurementUnit(models.TextChoices): > Aparentemente redundante (KG = "KG", "KG"), essa estrutura é necessária por limitações arquiteturais do próprio Django para enumeradores de texto. O primeiro parâmetro dita o valor bruto que será salvo de forma compacta no banco de dados, enquanto o segundo parâmetro define a label humana obrigatória para o Django Admin. Como o frontend agora faz o parse diretamente pelas siglas, igualei os dois valores para simplificar o modelo, otimizar o payload do JSON e remover a necessidade de strings extensas (como "Quilo") que causavam quebras de layout no mobile.

## ✅ Critérios de Aceite (Checklist)

* [x] A funcionalidade foi testada no simulador/celular.
* [ ] O código está coberto por testes e foi adotado o TDD.
* [x] O código segue as regras de estilização definidas no projeto.
* [x] Todo o código está em Inglês.

**Closes #26**