### PR TITLE
refactor: extrai MarketBanner para um componente reutilizável

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -51,7 +51,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    #"silk.middleware.SilkyMiddleware",
+    # "silk.middleware.SilkyMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4126,10 +4126,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -5318,10 +5317,9 @@
       }
     },
     "node_modules/expo/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -3,7 +3,7 @@ const BASE_URL = process.env.EXPO_PUBLIC_API_URL;
 export async function fetchHybridSearch(query: string) {
   // Performs hybrid search (products + markets) based on the typed term
 
-  if (!query.trim()) return {offers: []};
+  if (!query.trim()) return { offers: [] };
 
   const url = new URL(`${BASE_URL}/search/`);
   url.searchParams.append("query", query);

--- a/frontend/src/components/BottomNavbar.tsx
+++ b/frontend/src/components/BottomNavbar.tsx
@@ -9,7 +9,7 @@ import { StyleSheet, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { HomeScreen } from "../screens/HomeScreen";
 import { MyListScreen } from "../screens/MyListScreen";
-import { SearchResults } from "../screens/SearchResultsScreen";
+import { SearchResultsScreen } from "../screens/SearchResultsScreen";
 import { StoreProductsScreen } from "../screens/StoreProductsScreen";
 import { SupermarketsScreen } from "../screens/SupermarketsScreen";
 
@@ -77,9 +77,15 @@ function HomeStackScreen({
         {() => <HomeScreen location={location} />}
       </HomeStack.Screen>
 
-      <HomeStack.Screen name="SearchResults" component={SearchResults} />
+      <HomeStack.Screen
+        name="SearchResultsScreen"
+        component={SearchResultsScreen}
+      />
 
-      <HomeStack.Screen name="StoreProducts" component={StoreProductsScreen} />
+      <HomeStack.Screen
+        name="StoreProductsScreen"
+        component={StoreProductsScreen}
+      />
     </HomeStack.Navigator>
   );
 }
@@ -97,7 +103,7 @@ function SupermarketStackScreen() {
         component={SupermarketsScreen}
       />
       <SupermarketStack.Screen
-        name="StoreProducts"
+        name="StoreProductsScreen"
         component={StoreProductsScreen}
       />
     </SupermarketStack.Navigator>

--- a/frontend/src/components/MarketBanner.tsx
+++ b/frontend/src/components/MarketBanner.tsx
@@ -1,0 +1,63 @@
+import { StyleSheet, Text, View } from "react-native";
+
+interface MarketBannerProps {
+  marketName: string;
+  subtitle: string;
+}
+
+export function MarketBanner({ marketName, subtitle }: MarketBannerProps) {
+  const firstLetter = marketName ? marketName[0].toUpperCase() : "?";
+  const displayName = marketName ? marketName.toUpperCase() : "LOADING...";
+
+  return (
+    <View style={styles.marketBanner}>
+      <View style={styles.marketLogo}>
+        <Text style={styles.marketInitials}>{firstLetter}</Text>
+      </View>
+      <View>
+        <Text style={styles.marketName}>{displayName}</Text>
+        <Text style={styles.marketStatus}>{subtitle}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  marketBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 15,
+    backgroundColor: "#FFF",
+    marginHorizontal: 10,
+    borderRadius: 12,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: "#EEE",
+  },
+  marketInitials: {
+    fontSize: 20,
+    fontFamily: "Inter-Bold",
+    color: "#28a8b5",
+  },
+  marketLogo: {
+    width: 80,
+    height: 50,
+    borderRadius: 30,
+    backgroundColor: "#f8f8f8",
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 5,
+    borderWidth: 1,
+    borderColor: "#DDD",
+  },
+  marketName: {
+    fontFamily: "Inter-Bold",
+    fontSize: 16,
+    color: "#000",
+  },
+  marketStatus: {
+    fontSize: 10,
+    color: "#28a8b5",
+    fontFamily: "Inter-Bold",
+  },
+});

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -1,5 +1,12 @@
 import type React from "react";
-import { FlatList, StyleSheet, useWindowDimensions, View, type StyleProp, type ViewStyle } from "react-native";
+import {
+  FlatList,
+  type StyleProp,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+  type ViewStyle,
+} from "react-native";
 import type { Product } from "../types/product";
 import ProductCard from "./ProductCard";
 

--- a/frontend/src/components/ProductGrid.tsx
+++ b/frontend/src/components/ProductGrid.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { FlatList, StyleSheet, useWindowDimensions, View } from "react-native";
+import { FlatList, StyleSheet, useWindowDimensions, View, type StyleProp, type ViewStyle } from "react-native";
 import type { Product } from "../types/product";
 import ProductCard from "./ProductCard";
 
@@ -9,10 +9,10 @@ interface ProductGridProps {
   handleAddToList: (product: Product) => void;
   onEndReached?: () => void;
   onEndReachedThreshold?: number;
-  listFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
-  listHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;
-  listEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
-  contentContainerStyle?: any;
+  listFooterComponent?: React.ReactElement | null;
+  listHeaderComponent?: React.ReactElement | null;
+  listEmptyComponent?: React.ReactElement | null;
+  contentContainerStyle?: StyleProp<ViewStyle>;
 }
 
 const TABLET_LARGE = 1024;

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -12,6 +12,7 @@ import {
 } from "react-native";
 import { fetchHybridSearch } from "../api/search";
 import { colors } from "../theme/colors";
+import type { Product } from "../types/product";
 
 const { width: screenWidth } = Dimensions.get("window");
 
@@ -47,7 +48,7 @@ export const SearchBar = ({ initialValue = "" }: SearchBarProps) => {
         const data = await fetchHybridSearch(term);
 
         if (data.offers) {
-          const productNames = data.offers.map((item: any) => item.productName);
+          const productNames = data.offers.map((item: Product) => item.productName);
           const uniqueNames = Array.from(new Set(productNames));
           setSuggestions(uniqueNames as string[]);
         }

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -48,7 +48,9 @@ export const SearchBar = ({ initialValue = "" }: SearchBarProps) => {
         const data = await fetchHybridSearch(term);
 
         if (data.offers) {
-          const productNames = data.offers.map((item: Product) => item.productName);
+          const productNames = data.offers.map(
+            (item: Product) => item.productName,
+          );
           const uniqueNames = Array.from(new Set(productNames));
           setSuggestions(uniqueNames as string[]);
         }

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -39,7 +39,7 @@ export function HomeScreen({
   // NAVIGATION TO SPECIFIC MARKET SCREEN
   const handleMarketPress = useCallback(
     (market: Market) => {
-      navigation.navigate("StoreProducts", {
+      navigation.navigate("StoreProductsScreen", {
         selectedMarket: {
           id: market.id,
           name: market.name,

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,4 +1,8 @@
-import { useNavigation, type NavigationProp, type ParamListBase } from "@react-navigation/native";
+import {
+  type NavigationProp,
+  type ParamListBase,
+  useNavigation,
+} from "@react-navigation/native";
 import type * as Location from "expo-location";
 import { useCallback, useEffect, useState } from "react";
 import { StyleSheet, View } from "react-native";
@@ -14,7 +18,11 @@ import type { Product } from "../types/product";
 
 // SUPPORT FUNCTIONS
 
-export function HomeScreen({location}: {location: Location.LocationObject}) {
+export function HomeScreen({
+  location,
+}: {
+  location: Location.LocationObject;
+}) {
   const insets = useSafeAreaInsets();
   const [products, setProducts] = useState<Product[]>([]);
   const [page, setPage] = useState(1);

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, type NavigationProp, type ParamListBase } from "@react-navigation/native";
 import type * as Location from "expo-location";
 import { useCallback, useEffect, useState } from "react";
 import { StyleSheet, View } from "react-native";
@@ -14,18 +14,14 @@ import type { Product } from "../types/product";
 
 // SUPPORT FUNCTIONS
 
-export function HomeScreen({
-  location,
-}: {
-  location: Location.LocationObject;
-}) {
+export function HomeScreen({location}: {location: Location.LocationObject}) {
   const insets = useSafeAreaInsets();
   const [products, setProducts] = useState<Product[]>([]);
   const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
   const [hasMoreData, setHasMoreData] = useState(true);
   const [markets, setMarkets] = useState<Market[]>([]);
-  const navigation = useNavigation<any>();
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
 
   // ACTION WHEN CLICKING ON PRODUCT
   const handlePress = useCallback((product: Product) => {

--- a/frontend/src/screens/SearchResultsScreen.tsx
+++ b/frontend/src/screens/SearchResultsScreen.tsx
@@ -10,8 +10,19 @@ import ProductCard from "../components/ProductCard";
 import { SearchBar } from "../components/SearchBar";
 import type { Product } from "../types/product";
 
-export function SearchResultsScreen({ route }: any) {
-  const { query, selectedMarket, latitude, longitude } = route?.params;
+interface SearchResultsScreenProps {
+  route: {
+    params: {
+      query: string,
+      selectedMarket: {id: number, name: string;};
+      latitude?: number;
+      longitude?: number;
+    };
+  };
+}
+
+export function SearchResultsScreen({ route }: SearchResultsScreenProps) {
+  const { query, selectedMarket, latitude, longitude } = route.params;
 
   const [products, setProducts] = useState<Product[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -70,6 +81,7 @@ export function SearchResultsScreen({ route }: any) {
     }
   };
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: initial fetch on mount
   useEffect(() => {
     fetchData();
   }, []);

--- a/frontend/src/screens/SearchResultsScreen.tsx
+++ b/frontend/src/screens/SearchResultsScreen.tsx
@@ -5,12 +5,13 @@ import { fetchProducts } from "../api/products";
 import { EmptyProductState } from "../components/EmptyProductState";
 import { InfoBanner } from "../components/InfoBanner";
 import { LoadingFooter } from "../components/LoadingFooter";
+import { MarketBanner } from "../components/MarketBanner";
 import ProductCard from "../components/ProductCard";
 import { SearchBar } from "../components/SearchBar";
 import type { Product } from "../types/product";
 
-export function SearchResults({ route }: any) {
-  const { query, selectedMarket, latitude, longitude } = route.params || {};
+export function SearchResultsScreen({ route }: any) {
+  const { query, selectedMarket, latitude, longitude } = route?.params;
 
   const [products, setProducts] = useState<Product[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -24,19 +25,10 @@ export function SearchResults({ route }: any) {
         <SearchBar initialValue={query} />
 
         {selectedMarket && (
-          <View style={styles.marketBanner}>
-            <View style={styles.marketLogo}>
-              <Text style={styles.marketInitials}>
-                {selectedMarket.name[0]}
-              </Text>
-            </View>
-            <View>
-              <Text style={styles.marketName}>
-                {selectedMarket.name.toUpperCase()}
-              </Text>
-              <Text style={styles.marketStatus}>OFERTAS DA REDE</Text>
-            </View>
-          </View>
+          <MarketBanner
+            marketName={selectedMarket.name}
+            subtitle={"OFERTAS DA REDE"}
+          ></MarketBanner>
         )}
 
         <InfoBanner />
@@ -103,7 +95,6 @@ export function SearchResults({ route }: any) {
           <View style={styles.cardWrapper}>
             <ProductCard
               product={{ ...item, ranking: index + 1 }}
-              isGrid={true}
               handlePress={() => console.log("Clicked on product")}
               handleAddToList={() => console.log("Added to list")}
             />
@@ -144,42 +135,5 @@ const styles = StyleSheet.create({
     color: "#333",
     marginVertical: 15,
     marginLeft: 10,
-  },
-  marketBanner: {
-    flexDirection: "row",
-    alignItems: "center",
-    padding: 15,
-    backgroundColor: "#FFF",
-    marginHorizontal: 10,
-    borderRadius: 12,
-    marginBottom: 10,
-    borderWidth: 1,
-    borderColor: "#EEE",
-  },
-  marketInitials: {
-    fontSize: 20,
-    fontFamily: "Inter-Bold",
-    color: "#28a8b5",
-  },
-  marketLogo: {
-    width: 80,
-    height: 50,
-    borderRadius: 30,
-    backgroundColor: "#f8f8f8",
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: 5,
-    borderWidth: 1,
-    borderColor: "#DDD",
-  },
-  marketName: {
-    fontFamily: "Inter-Bold",
-    fontSize: 16,
-    color: "#000",
-  },
-  marketStatus: {
-    fontSize: 10,
-    color: "#28a8b5",
-    fontFamily: "Inter-Bold",
   },
 });

--- a/frontend/src/screens/SearchResultsScreen.tsx
+++ b/frontend/src/screens/SearchResultsScreen.tsx
@@ -13,8 +13,8 @@ import type { Product } from "../types/product";
 interface SearchResultsScreenProps {
   route: {
     params: {
-      query: string,
-      selectedMarket: {id: number, name: string;};
+      query: string;
+      selectedMarket: { id: number; name: string };
       latitude?: number;
       longitude?: number;
     };

--- a/frontend/src/screens/StoreProductsScreen.tsx
+++ b/frontend/src/screens/StoreProductsScreen.tsx
@@ -12,14 +12,14 @@ import type { Product } from "../types/product";
 interface StoreProductsScreenProps {
   route: {
     params: {
-      selectedMarket: {id: number, name: string;};
+      selectedMarket: { id: number; name: string };
       latitude?: number;
       longitude?: number;
     };
   };
 }
 
-export function StoreProductsScreen({route}: StoreProductsScreenProps) {
+export function StoreProductsScreen({ route }: StoreProductsScreenProps) {
   const insets = useSafeAreaInsets();
   const { selectedMarket, latitude, longitude } = route.params;
 

--- a/frontend/src/screens/StoreProductsScreen.tsx
+++ b/frontend/src/screens/StoreProductsScreen.tsx
@@ -4,6 +4,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { fetchProducts } from "../api/products";
 import { EmptyProductState } from "../components/EmptyProductState";
 import { LoadingFooter } from "../components/LoadingFooter";
+import { MarketBanner } from "../components/MarketBanner";
 import { ProductGrid } from "../components/ProductGrid";
 import { SearchBar } from "../components/SearchBar";
 import type { Product } from "../types/product";
@@ -51,21 +52,15 @@ export function StoreProductsScreen({ route }: any) {
   }, []);
 
   const Header = () => {
-    const actualName = selectedMarket?.name || selectedMarket?.marketName || "";
-    const firstLetter = actualName ? actualName[0].toUpperCase() : "?";
-    const displayName = actualName ? actualName.toUpperCase() : "LOADING...";
+    const actualName: string = selectedMarket?.name || "";
+    const displayName: string = actualName.toUpperCase();
 
     return (
       <View style={styles.headerContainer}>
-        <View style={styles.marketBanner}>
-          <View style={styles.marketLogo}>
-            <Text style={styles.marketInitials}>{firstLetter}</Text>
-          </View>
-          <View>
-            <Text style={styles.marketName}>{displayName}</Text>
-            <Text style={styles.marketStatus}>OFERTAS DESTA UNIDADE</Text>
-          </View>
-        </View>
+        <MarketBanner
+          marketName={displayName}
+          subtitle="OFERTAS DESTA UNIDADE"
+        ></MarketBanner>
       </View>
     );
   };
@@ -112,8 +107,8 @@ export function StoreProductsScreen({ route }: any) {
         }
         onEndReached={fetchData}
         onEndReachedThreshold={0.7}
-        ListHeaderComponent={<Header />}
-        ListFooterComponent={renderFooter()}
+        listHeaderComponent={<Header />}
+        listFooterComponent={renderFooter()}
         contentContainerStyle={styles.gridContainer}
       />
     </View>
@@ -128,43 +123,5 @@ const styles = StyleSheet.create({
   gridContainer: {
     paddingHorizontal: 14,
     flexGrow: 1,
-  },
-  marketBanner: {
-    flexDirection: "row",
-    alignItems: "center",
-    padding: 15,
-    backgroundColor: "#FFF",
-    marginHorizontal: 0,
-    borderRadius: 12,
-    marginBottom: 10,
-    borderWidth: 1,
-    borderColor: "#EEE",
-    alignSelf: "stretch",
-  },
-  marketInitials: {
-    fontSize: 20,
-    fontFamily: "Inter-Bold",
-    color: "#28a8b5",
-  },
-  marketLogo: {
-    width: 80,
-    height: 50,
-    borderRadius: 30,
-    backgroundColor: "#f8f8f8",
-    justifyContent: "center",
-    alignItems: "center",
-    marginRight: 5,
-    borderWidth: 1,
-    borderColor: "#DDD",
-  },
-  marketName: {
-    fontFamily: "Inter-Bold",
-    fontSize: 16,
-    color: "#000",
-  },
-  marketStatus: {
-    fontSize: 10,
-    color: "#28a8b5",
-    fontFamily: "Inter-Bold",
   },
 });

--- a/frontend/src/screens/StoreProductsScreen.tsx
+++ b/frontend/src/screens/StoreProductsScreen.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { useEffect, useState } from "react";
+import { StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { fetchProducts } from "../api/products";
 import { EmptyProductState } from "../components/EmptyProductState";
@@ -9,16 +9,29 @@ import { ProductGrid } from "../components/ProductGrid";
 import { SearchBar } from "../components/SearchBar";
 import type { Product } from "../types/product";
 
-export function StoreProductsScreen({ route }: any) {
+interface StoreProductsScreenProps {
+  route: {
+    params: {
+      selectedMarket: {id: number, name: string;};
+      latitude?: number;
+      longitude?: number;
+    };
+  };
+}
+
+export function StoreProductsScreen({route}: StoreProductsScreenProps) {
   const insets = useSafeAreaInsets();
-  const { selectedMarket, latitude, longitude } = route.params || {};
+  const { selectedMarket, latitude, longitude } = route.params;
 
   const [products, setProducts] = useState<Product[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [page, setPage] = useState(1);
   const [hasMoreData, setHasMoreData] = useState(true);
 
-  const fetchData = useCallback(async () => {
+  const actualName: string = selectedMarket?.name || "";
+  const displayName: string = actualName.toUpperCase();
+
+  const fetchData = async () => {
     if (isLoading || !hasMoreData) return;
     setIsLoading(true);
 
@@ -45,25 +58,21 @@ export function StoreProductsScreen({ route }: any) {
     } finally {
       setIsLoading(false);
     }
-  }, [page, isLoading, hasMoreData, selectedMarket.id, latitude, longitude]);
+  };
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: initial fetch on mount
   useEffect(() => {
     fetchData();
   }, []);
 
-  const Header = () => {
-    const actualName: string = selectedMarket?.name || "";
-    const displayName: string = actualName.toUpperCase();
-
-    return (
-      <View style={styles.headerContainer}>
-        <MarketBanner
-          marketName={displayName}
-          subtitle="OFERTAS DESTA UNIDADE"
-        ></MarketBanner>
-      </View>
-    );
-  };
+  const headerElement = (
+    <View style={styles.headerContainer}>
+      <MarketBanner
+        marketName={displayName}
+        subtitle="OFERTAS DESTA UNIDADE"
+      ></MarketBanner>
+    </View>
+  );
 
   const renderFooter = () => {
     if (isLoading) {
@@ -107,7 +116,7 @@ export function StoreProductsScreen({ route }: any) {
         }
         onEndReached={fetchData}
         onEndReachedThreshold={0.7}
-        listHeaderComponent={<Header />}
+        listHeaderComponent={headerElement}
         listFooterComponent={renderFooter()}
         contentContainerStyle={styles.gridContainer}
       />


### PR DESCRIPTION
## O que foi entregue?
Eu isolei o trecho de código que tratava das informações do mercado em um único componente (pois ele era usando tanto em `StoreProductsScreen.tsx`, quanto em `SearchResultsScreen.tsx`), evitando repetição de código: 

<img width="669" height="376" alt="image" src="https://github.com/user-attachments/assets/2252aa8e-725c-499e-917f-6ee3ecb0b199" />

Passou a utilizar o `MarketBanner.tsx`:

<img width="421" height="228" alt="image" src="https://github.com/user-attachments/assets/32ba2945-91e5-4fa3-89b2-342aeffe3dec" />

Closes #28.

## ✅ Critérios de Aceite (Checklist)
- [X] A funcionalidade foi testada no simulador/celular.
- [ ] O código está coberto por testes e foi adotado o TDD.
- [X] O código segue as regras de estilização definidas no projeto.
- [X] Todo o código está em Inglês.