### PR TITLE
chore: modificando o 'pytest-exec.yml' para não rodar testes de integração

### DIFF
--- a/.github/workflows/pytest-exec.yml
+++ b/.github/workflows/pytest-exec.yml
@@ -40,4 +40,4 @@ jobs:
           DJANGO_SETTINGS_MODULE: core.settings_test
         run: |
           cd backend
-          pytest --no-migrations .
+          pytest -m "not integration" --no-migrations .


### PR DESCRIPTION
## O que foi entregue?
Eu alterei o arquivo `pytest-exec.yml` para que ele não execute testes marcados como testes de integração (pytest.mark.integration). 

Essa mudança é necessária pois como testes de integração dependem de fatores externos para rodar corretamente, uma falha nesse tipo de teste não significa que algo na lógica do código falhou, mas sim que algo no serviço externo falhou. Portanto, um PR não deve ser barrado apenas porque o teste de integração falhou.