### PR TITLE
docs(scraping): aprimoramento de docstring de métricas e refatoração logs do webscraping

### DIFF
--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -25,12 +25,7 @@ def scrap_supermarket_page(url: str):
     market_slug = url.strip("/").split("/")[-1]
 
     # metrics dictionary to be used in the final summary report
-    metrics = {
-        "market": market_slug,
-        "status": "success",
-        "downloaded_images": 0,
-        "reason": ""
-    }
+    metrics = {"market": market_slug, "status": "success", "downloaded_images": 0, "reason": ""}
 
     try:
         # If this supermarket link has already been scrapped, we skip
@@ -103,15 +98,9 @@ def generate_scraping_report(results):
 
     total_markets = len(results)
     total_images = sum(item["downloaded_images"] for item in results if item)
-    successful_markets = sum(
-        1 for item in results if item and item["status"] == "success"
-    )
-    skipped_markets = sum(
-        1 for item in results if item and item["status"] == "skipped"
-    )
-    failed_markets = sum(
-        1 for item in results if item and item["status"] == "error"
-    )
+    successful_markets = sum(1 for item in results if item and item["status"] == "success")
+    skipped_markets = sum(1 for item in results if item and item["status"] == "skipped")
+    failed_markets = sum(1 for item in results if item and item["status"] == "error")
 
     report = f"""
 ======================================================================
@@ -137,7 +126,7 @@ def generate_scraping_report(results):
             "error": "❌",
         }
         status_icon = icons.get(item["status"], icons["error"])
-        reason_str = f" ({item['reason']})" if item['reason'] else ""
+        reason_str = f" ({item['reason']})" if item["reason"] else ""
         report += (
             f"  {status_icon} {item['market'].upper()}:"
             f" {item['downloaded_images']} image(s) saved{reason_str}\n"
@@ -190,11 +179,13 @@ def scrap_home_page():
 
         # Launching the parallel execution group and binding it to the report callback
         if tasks_to_run:
-            logger.info(f"Home Page analysis finished. Launching chord workflow for {len(tasks_to_run)} tasks.")
+            logger.info(
+                f"""Home Page analysis finished.
+                Launching chord workflow for {len(tasks_to_run)} tasks."""
+            )
             chord(tasks_to_run)(generate_scraping_report.s())
         else:
             logger.info("No active supermarket offers found to process.")
 
     except Exception as e:
         logger.error(f"Error when scraping the Home Page: {e}")
-

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -17,21 +17,8 @@ FLYERS_BASE_DIR = Path(tempfile.gettempdir()) / "flyers"
 def scrap_supermarket_page(url: str):
     """
     Scrapes a specific supermarket page and downloads all available flyer images.
-
     This task runs in parallel for each supermarket link found on the landing index.
     It collects and returns execution statistics to feed the final orchestration report.
-
-    Args:
-        url (str): The absolute supermarket target URL from the scraping index.
-
-    Returns:
-        dict: A dictionary containing the task metrics following this structure:
-            {
-                "market": str,             # Sluggified name of the supermarket establishment
-                "status": str,
-                "downloaded_images": int,
-                "reason": str,
-            }
     """
 
     FLYERS_BASE_DIR.mkdir(parents=True, exist_ok=True)
@@ -48,8 +35,6 @@ def scrap_supermarket_page(url: str):
     try:
         # If this supermarket link has already been scrapped, we skip
         if Offer.objects.filter(url=url).exists():
-            logger.debug(f"Supermarket URL already processed. Skipping: {url}")
-            # metrics["downloaded_images"]
             metrics["status"] = "skipped"
             metrics["reason"] = "Already processed"
             return metrics
@@ -67,12 +52,10 @@ def scrap_supermarket_page(url: str):
             )
         )
 
-        logger.info(f"Created temporary directory for {market_slug}: {new_temp_folder}")
-
+        # Represent the flyers list in the page
         img_tags = soup.select_one(".text").find_next("p").select("img")
         download_count = 0
 
-        # Looping through all flyers found in the page
         for index, img_tag in enumerate(img_tags):
             src = img_tag.get("data-src") or img_tag.get("src")
             if not src:
@@ -94,8 +77,6 @@ def scrap_supermarket_page(url: str):
 
             download_count += 1
 
-        logger.info(f"Successfully downloaded {download_count} flyers for {market_slug}")
-
         # Updating metrics for the final summary report
         metrics["downloaded_images"] = download_count
         return metrics
@@ -112,9 +93,10 @@ def scrap_supermarket_page(url: str):
 @shared_task
 def generate_scraping_report(results):
     """
-    CALLBACK TASK: Triggered automatically by Celery if and only when
+    Triggered automatically by Celery if and only when
     every single queued supermarket task completes execution.
     """
+
     if not results:
         logger.warning("No scraping results collected for the report.")
         return
@@ -154,7 +136,7 @@ def generate_scraping_report(results):
             "skipped": "⏩",
             "error": "❌",
         }
-        status_icon = icons.get(item["status"], "❌")
+        status_icon = icons.get(item["status"], icons["error"])
         reason_str = f" ({item['reason']})" if item['reason'] else ""
         report += (
             f"  {status_icon} {item['market'].upper()}:"
@@ -178,8 +160,6 @@ def scrap_home_page():
     URL = "https://encartesdf.com.br/"
     FLYERS_BASE_DIR.mkdir(parents=True, exist_ok=True)
 
-    logger.info("Starting Home Page scraping process...")
-
     try:
         response = requests.get(URL, headers={"User-Agent": "Mozilla/5.0"})
         response.raise_for_status()
@@ -189,7 +169,7 @@ def scrap_home_page():
         # Each supermarket link ('a' tag) is located in the following 'h1' tags.
         h1_tags = soup.select(".main-title")
 
-        # Array created to safely accumulate task signatures for the chord pipeline
+        # Array created to accumulate task signatures for the chord pipeline
         tasks_to_run = []
 
         for h1_tag in h1_tags:
@@ -201,29 +181,16 @@ def scrap_home_page():
 
             # If the supermarket offer is expired, we skip
             if a_tag.select_one(".badge-vencido"):
-                logger.debug(f"Skipping expired offer: {a_tag.text.strip()}")
                 continue
 
             market_url = a_tag.get("href")
-
-            # If this supermarket link has already been scrapped, we append it to the list
-            # with signature syntax (.s) so the final report knows it was skipped
-            if Offer.objects.filter(url=market_url).exists():
-                logger.debug(f"Offer already exists in database. Skipping: {market_url}")
-                tasks_to_run.append(scrap_supermarket_page.s(market_url))
-                continue
-
-            logger.info(f"Queueing new supermarket for scraping: {market_url}")
 
             # Appending active scraping tasks to the batch signature array
             tasks_to_run.append(scrap_supermarket_page.s(market_url))
 
         # Launching the parallel execution group and binding it to the report callback
         if tasks_to_run:
-            logger.info(
-                "Home Page analysis finished."
-                f" Launching chord workflow for {len(tasks_to_run)} tasks."
-            )
+            logger.info(f"Home Page analysis finished. Launching chord workflow for {len(tasks_to_run)} tasks.")
             chord(tasks_to_run)(generate_scraping_report.s())
         else:
             logger.info("No active supermarket offers found to process.")

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import requests
 from bs4 import BeautifulSoup
-from celery import shared_task
+from celery import chord, shared_task
 
 from .models import Offer
 
@@ -16,23 +16,48 @@ FLYERS_BASE_DIR = Path(tempfile.gettempdir()) / "flyers"
 @shared_task
 def scrap_supermarket_page(url: str):
     """
-    This function visits the given supermarket URL and downloads all the flyers
-    of the page into a temporary directory.
+    Scrapes a specific supermarket page and downloads all available flyer images.
+
+    This task runs in parallel for each supermarket link found on the landing index.
+    It collects and returns execution statistics to feed the final orchestration report.
+
+    Args:
+        url (str): The absolute supermarket target URL from the scraping index.
+
+    Returns:
+        dict: A dictionary containing the task metrics following this structure:
+            {
+                "market": str,             # Sluggified name of the supermarket establishment
+                "status": str,
+                "downloaded_images": int,
+                "reason": str,
+            }
     """
 
     FLYERS_BASE_DIR.mkdir(parents=True, exist_ok=True)
+    market_slug = url.strip("/").split("/")[-1]
+
+    # metrics dictionary to be used in the final summary report
+    metrics = {
+        "market": market_slug,
+        "status": "success",
+        "downloaded_images": 0,
+        "reason": ""
+    }
 
     try:
         # If this supermarket link has already been scrapped, we skip
         if Offer.objects.filter(url=url).exists():
             logger.debug(f"Supermarket URL already processed. Skipping: {url}")
-            return
+            # metrics["downloaded_images"]
+            metrics["status"] = "skipped"
+            metrics["reason"] = "Already processed"
+            return metrics
 
         response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"})
         response.raise_for_status()
 
         soup = BeautifulSoup(response.text, "html.parser")
-        market_slug = url.strip("/").split("/")[-1]
 
         # Creating a temporary folder to download the supermarket's flyers
         new_temp_folder = Path(
@@ -71,16 +96,83 @@ def scrap_supermarket_page(url: str):
 
         logger.info(f"Successfully downloaded {download_count} flyers for {market_slug}")
 
+        # Updating metrics for the final summary report
+        metrics["downloaded_images"] = download_count
+        return metrics
+
     except Exception as e:
         logger.error(f"Error when scraping the Supermarket page ({url}): {e}")
+
+        # Capturing the failure details to include in the final report
+        metrics["status"] = "error"
+        metrics["reason"] = str(e)
+        return metrics
+
+
+@shared_task
+def generate_scraping_report(results):
+    """
+    CALLBACK TASK: Triggered automatically by Celery if and only when
+    every single queued supermarket task completes execution.
+    """
+    if not results:
+        logger.warning("No scraping results collected for the report.")
+        return
+
+    total_markets = len(results)
+    total_images = sum(item["downloaded_images"] for item in results if item)
+    successful_markets = sum(
+        1 for item in results if item and item["status"] == "success"
+    )
+    skipped_markets = sum(
+        1 for item in results if item and item["status"] == "skipped"
+    )
+    failed_markets = sum(
+        1 for item in results if item and item["status"] == "error"
+    )
+
+    report = f"""
+======================================================================
+📊 FINAL SCRAPING REPORT - Compare prices
+======================================================================
+🏁 Execution Status: COMPLETED
+🏪 Total Establishments Evaluated: {total_markets}
+✅ Supermarkets Processed Successfully: {successful_markets}
+⏩ Supermarkets Skipped (Existing Data): {skipped_markets}
+❌ Supermarkets with Execution Errors: {failed_markets}
+🖼️ Total Images/Flyers Downloaded: {total_images}
+
+----------------------------------------------------------------------
+📋 Detailed Breakdown per Establishment:
+----------------------------------------------------------------------
+"""
+    for item in results:
+        if not item:
+            continue
+        icons = {
+            "success": "✅",
+            "skipped": "⏩",
+            "error": "❌",
+        }
+        status_icon = icons.get(item["status"], "❌")
+        reason_str = f" ({item['reason']})" if item['reason'] else ""
+        report += (
+            f"  {status_icon} {item['market'].upper()}:"
+            f" {item['downloaded_images']} image(s) saved{reason_str}\n"
+        )
+
+    report += "======================================================================"
+
+    print(report)
+    logger.info("Scraping workflow completed execution.")
 
 
 @shared_task
 def scrap_home_page():
     """
     This function scraps the home page of the "https://encartesdf.com.br/" URL.
-    For each supermarket link found, it'll be added in the Redis queue for scraping
-    later.
+    For each supermarket link found, it compiles a chord execution graph
+    to trigger a unified summary report once all downloads finish.
     """
 
     URL = "https://encartesdf.com.br/"
@@ -96,7 +188,9 @@ def scrap_home_page():
 
         # Each supermarket link ('a' tag) is located in the following 'h1' tags.
         h1_tags = soup.select(".main-title")
-        queued_count = 0
+
+        # Array created to safely accumulate task signatures for the chord pipeline
+        tasks_to_run = []
 
         for h1_tag in h1_tags:
             a_tag = h1_tag.select_one("a")
@@ -112,18 +206,28 @@ def scrap_home_page():
 
             market_url = a_tag.get("href")
 
-            # If this supermarket link has already been scrapped, we skip
+            # If this supermarket link has already been scrapped, we append it to the list
+            # with signature syntax (.s) so the final report knows it was skipped
             if Offer.objects.filter(url=market_url).exists():
                 logger.debug(f"Offer already exists in database. Skipping: {market_url}")
+                tasks_to_run.append(scrap_supermarket_page.s(market_url))
                 continue
 
             logger.info(f"Queueing new supermarket for scraping: {market_url}")
 
-            # Queueing in Redis
-            scrap_supermarket_page.delay(market_url)
-            queued_count += 1
+            # Appending active scraping tasks to the batch signature array
+            tasks_to_run.append(scrap_supermarket_page.s(market_url))
 
-        logger.info(f"Home Page scraping finished. {queued_count} tasks queued.")
+        # Launching the parallel execution group and binding it to the report callback
+        if tasks_to_run:
+            logger.info(
+                "Home Page analysis finished."
+                f" Launching chord workflow for {len(tasks_to_run)} tasks."
+            )
+            chord(tasks_to_run)(generate_scraping_report.s())
+        else:
+            logger.info("No active supermarket offers found to process.")
 
     except Exception as e:
         logger.error(f"Error when scraping the Home Page: {e}")
+

--- a/backend/app/tests/unit/test_tasks.py
+++ b/backend/app/tests/unit/test_tasks.py
@@ -41,14 +41,20 @@ class TestScrapHomePageTask:
     Class destined to the elaboration of tests of the 'scrap_home_page' task.
     """
 
-    @patch("app.tasks.scrap_supermarket_page.delay")
+    @patch("app.tasks.chord")
+    @patch("app.tasks.scrap_supermarket_page.s")
     @patch("app.tasks.requests.get")
     def test_scrap_home_page_with_real_snapshot(
-        self, mock_requests_get, mock_task_delay, home_page_html_content, mock_flyers_directory
+        self,
+        mock_requests_get,
+        mock_task_s,
+        mock_chord,
+        home_page_html_content,
+        mock_flyers_directory,
     ):
         """
         Testing the home page scraping logic using a real HTML snapshot.
-        It should parse the HTML correctly and queue the valid supermarkets.
+        It should parse the HTML correctly and queue the valid supermarkets using signatures.
         """
 
         mocked_response = MagicMock()
@@ -58,10 +64,10 @@ class TestScrapHomePageTask:
 
         scrap_home_page()
 
-        assert mock_task_delay.call_count > 0
-
-        first_queued_url = mock_task_delay.call_args_list[0][0][0]
+        assert mock_task_s.call_count > 0
+        first_queued_url = mock_task_s.call_args_list[0][0][0]
         assert "encartesdf.com.br" in first_queued_url
+        assert mock_chord.call_count == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION

- Substituída a docstring antiga de 'scrap_supermarket_page' por uma documentação estruturada com mapeamento explícito do dicionário de métricas de retorno.
- Refatorada a lógica de ícones por status dentro de 'generate_scraping_report' usando um dicionário de mapeamento direto.
- Removidos comentários antigos e códigos mortos remanescentes do bloco de verificação de ofertas existentes.

## O que foi entregue?
> Relatório ao fim da busca dos panfletos, quando o scrapping termina, no terminal.

## ✅ Critérios de Aceite (Checklist)
- [x] A funcionalidade foi testada no simulador/celular.
- [x] O código está coberto por testes e foi adotado o TDD.
- [x] O código segue as regras de estilização definidas no projeto.
- [x] Todo o código está em Inglês.